### PR TITLE
feat: fit with LiNEAR stake interface

### DIFF
--- a/contracts/mock-linear/src/lib.rs
+++ b/contracts/mock-linear/src/lib.rs
@@ -31,7 +31,7 @@ impl MockLinear {
     // -- public LiNEAR methods
 
     #[payable]
-    pub fn deposit_and_stake_v2(&mut self) -> U128 {
+    pub fn deposit_and_stake(&mut self) -> U128 {
         require!(!self.panic, "LiNEAR Panic");
         let account_id = env::predecessor_account_id();
         let amount = env::attached_deposit();

--- a/contracts/phoenix-bonds/src/interfaces/linear.rs
+++ b/contracts/phoenix-bonds/src/interfaces/linear.rs
@@ -2,6 +2,6 @@ use near_sdk::{ext_contract, json_types::U128};
 
 #[ext_contract(linear_contract)]
 pub trait LiNEARInterface {
-    fn deposit_and_stake_v2(&self) -> U128;
+    fn deposit_and_stake(&self) -> U128;
     fn ft_price(&self) -> U128;
 }

--- a/contracts/phoenix-bonds/src/lib.rs
+++ b/contracts/phoenix-bonds/src/lib.rs
@@ -151,7 +151,7 @@ impl PhoenixBonds {
         linear_contract::ext(self.linear_address.clone())
             .with_static_gas(GAS_DEPOSIT_AND_STAKE)
             .with_attached_deposit(bond_amount)
-            .deposit_and_stake_v2()
+            .deposit_and_stake()
             .then(
                 Self::ext(env::current_account_id())
                     .with_static_gas(GAS_BOND_CALLBACK)

--- a/tests/__tests__/mock_linear.ava.ts
+++ b/tests/__tests__/mock_linear.ava.ts
@@ -9,7 +9,7 @@ test("Stake at LiNEAR price 1", async (test) => {
 
   const shares: string = await alice.call(
     linear,
-    "deposit_and_stake_v2",
+    "deposit_and_stake",
     {},
     {
       attachedDeposit: stakeAmount,
@@ -31,7 +31,7 @@ test("Stake at LiNEAR price 1.2", async (test) => {
 
   const shares: string = await alice.call(
     linear,
-    "deposit_and_stake_v2",
+    "deposit_and_stake",
     {},
     {
       attachedDeposit: stakeAmount,
@@ -47,7 +47,7 @@ test("Transfer LiNEAR", async (test) => {
 
   await alice.call(
     linear,
-    "deposit_and_stake_v2",
+    "deposit_and_stake",
     {},
     {
       attachedDeposit: stakeAmount,
@@ -57,7 +57,7 @@ test("Transfer LiNEAR", async (test) => {
   // to make bob registered
   await bob.call(
     linear,
-    "deposit_and_stake_v2",
+    "deposit_and_stake",
     {},
     {
       attachedDeposit: stakeAmount,


### PR DESCRIPTION
After updating LiNEAR stake interface in https://github.com/linear-protocol/LiNEAR/pull/130, make Phoenix Bonds compatible with the latest version. 