### PR TITLE
chore: lint-staged warning

### DIFF
--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -8,7 +8,7 @@ export default {
   "tests/**/*.{js,jsx,ts,tsx}": [
     "prettier --write"
   ],
-  "bin/**/*.{js}": [
+  "bin/**/*.js": [
     "prettier --write"
   ],
 };


### PR DESCRIPTION
Remove lint-staged warning:

```bash
⚠ Detected incorrect braces with only single value: `bin/**/*.{js}`. Reformatted as: `bin/**/*.js`
```